### PR TITLE
QuickPulse - scheduling

### DIFF
--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -130,7 +130,7 @@
 
                 bool? keepCollecting = this.serviceClient.SubmitSamples(dataSamplesToSubmit, instrumentationKey);
 
-                QuickPulseEventSource.Log.TroubleshootingMessageEvent(string.Format(CultureInfo.InvariantCulture, "Sample submitted. Response: '{0}'", keepCollecting));
+                QuickPulseEventSource.Log.SampleSubmittedEvent(keepCollecting.ToString());
 
                 switch (keepCollecting)
                 {
@@ -157,7 +157,7 @@
                 // we are currently idle and pinging the service waiting for it to ask us to start collecting data
                 bool? startCollection = this.serviceClient.Ping(instrumentationKey, this.timeProvider.UtcNow);
 
-                QuickPulseEventSource.Log.TroubleshootingMessageEvent(string.Format(CultureInfo.InvariantCulture, "Ping sent. Response: '{0}'", startCollection));
+                QuickPulseEventSource.Log.PingSentEvent(startCollection.ToString());
 
                 switch (startCollection)
                 {

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseDataSample.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseDataSample.cs
@@ -67,26 +67,6 @@
             // avoiding reflection (Enum.GetNames()) to speed things up
             Tuple<PerformanceCounterData, float> value;
 
-            if (perfData.TryGetValue(QuickPulsePerfCounters.PerfIisRequestsPerSecond.ToString(), out value))
-            {
-                this.PerfIisRequestsPerSecond = value.Item2;
-            }
-
-            if (perfData.TryGetValue(QuickPulsePerfCounters.PerfIisRequestDurationAve.ToString(), out value))
-            {
-                this.PerfIisRequestDurationAveInTicks = value.Item2;
-            }
-
-            if (perfData.TryGetValue(QuickPulsePerfCounters.PerfIisRequestsFailedTotal.ToString(), out value))
-            {
-                this.PerfIisRequestsFailedTotal = value.Item2;
-            }
-
-            if (perfData.TryGetValue(QuickPulsePerfCounters.PerfIisRequestsSucceededTotal.ToString(), out value))
-            {
-                this.PerfIisRequestsSucceededTotal = value.Item2;
-            }
-
             if (perfData.TryGetValue(QuickPulsePerfCounters.PerfIisQueueSize.ToString(), out value))
             {
                 this.PerfIisQueueSize = value.Item2;
@@ -137,14 +117,6 @@
         #region Performance counters
 
         public IDictionary<string, float> PerfCountersLookup { get; private set; }
-
-        public double PerfIisRequestsPerSecond { get; private set; }
-
-        public double PerfIisRequestDurationAveInTicks { get; private set; }
-
-        public double PerfIisRequestsFailedTotal { get; private set; }
-
-        public double PerfIisRequestsSucceededTotal { get; private set; }
 
         public double PerfIisQueueSize { get; private set; }
 

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -108,6 +108,36 @@
             this.WriteEvent(14, message ?? string.Empty, this.ApplicationName);
         }
 
+        [Event(15, Message = "Sample submitted. Response: '{0}'", Level = EventLevel.Verbose)]
+        public void SampleSubmittedEvent(string response, string applicationName = "dummy")
+        {
+            this.WriteEvent(15, response ?? string.Empty, this.ApplicationName);
+        }
+
+        [Event(16, Message = "Ping sent. Response: '{0}'", Level = EventLevel.Verbose)]
+        public void PingSentEvent(string response, string applicationName = "dummy")
+        {
+            this.WriteEvent(16, response ?? string.Empty, this.ApplicationName);
+        }
+
+        [Event(17, Message = "State timer tick finished: {0} ms", Level = EventLevel.Verbose)]
+        public void StateTimerTickFinishedEvent(long elapsedMs, string applicationName = "dummy")
+        {
+            this.WriteEvent(17, elapsedMs, this.ApplicationName);
+        }
+
+        [Event(18, Message = "Collection timer tick finished: {0} ms", Level = EventLevel.Verbose)]
+        public void CollectionTimerTickFinishedEvent(long elapsedMs, string applicationName = "dummy")
+        {
+            this.WriteEvent(18, elapsedMs, this.ApplicationName);
+        }
+
+        [Event(19, Message = "Sample stored. Buffer length: {0}", Level = EventLevel.Verbose)]
+        public void SampleStoredEvent(int bufferLength, string applicationName = "dummy")
+        {
+            this.WriteEvent(19, bufferLength, this.ApplicationName);
+        }
+
         #endregion
 
         [NonEvent]

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulsePerfCounterList.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulsePerfCounterList.cs
@@ -11,10 +11,6 @@
             =>
                 new[]
                     {
-                        Tuple.Create(QuickPulsePerfCounters.PerfIisRequestsPerSecond, @"\ASP.NET Applications(__Total__)\Requests/Sec"),
-                        Tuple.Create(QuickPulsePerfCounters.PerfIisRequestDurationAve, @"\ASP.NET Applications(__Total__)\Request Execution Time"),
-                        Tuple.Create(QuickPulsePerfCounters.PerfIisRequestsFailedTotal, @"\ASP.NET Applications(__Total__)\Requests Failed"),
-                        Tuple.Create(QuickPulsePerfCounters.PerfIisRequestsSucceededTotal, @"\ASP.NET Applications(__Total__)\Requests Succeeded"),
                         Tuple.Create(QuickPulsePerfCounters.PerfIisQueueSize, @"\ASP.NET Applications(__Total__)\Requests In Application Queue"),
                         Tuple.Create(QuickPulsePerfCounters.PerfCpuUtilization, @"\Memory\Committed Bytes"),
                         Tuple.Create(QuickPulsePerfCounters.PerfMemoryInBytes, @"\Processor(_Total)\% Processor Time")

--- a/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulsePerfCounters.cs
+++ b/Src/PerformanceCollector/Shared/Implementation/QuickPulse/QuickPulsePerfCounters.cs
@@ -2,14 +2,6 @@
 {
     internal enum QuickPulsePerfCounters
     {
-        PerfIisRequestsPerSecond,
-
-        PerfIisRequestDurationAve,
-
-        PerfIisRequestsFailedTotal,
-
-        PerfIisRequestsSucceededTotal,
-
         PerfIisQueueSize,
 
         PerfCpuUtilization,

--- a/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
+++ b/Src/PerformanceCollector/Shared/QuickPulseTelemetryModule.cs
@@ -318,7 +318,7 @@
             }
             finally
             {
-                QuickPulseEventSource.Log.TroubleshootingMessageEvent(string.Format(CultureInfo.InvariantCulture, "State timer tick finished: {0} ms", stopwatch.ElapsedMilliseconds));
+                QuickPulseEventSource.Log.StateTimerTickFinishedEvent(stopwatch.ElapsedMilliseconds);
 
                 if (this.stateTimer != null)
                 {
@@ -357,7 +357,7 @@
             }
             finally
             {
-                QuickPulseEventSource.Log.TroubleshootingMessageEvent(string.Format(CultureInfo.InvariantCulture, "Collection timer tick finished: {0} ms", stopwatch.ElapsedMilliseconds));
+                QuickPulseEventSource.Log.CollectionTimerTickFinishedEvent(stopwatch.ElapsedMilliseconds);
 
                 // this is in a race condition with stopping timer from OnStopCollection, so we need to ensure that we don't schedule the next tick more than once
                 // after the timer has been ordered to stop
@@ -379,7 +379,7 @@
         {
             lock (this.collectedSamplesLock)
             {
-                QuickPulseEventSource.Log.TroubleshootingMessageEvent(string.Format(CultureInfo.InvariantCulture, "Sample stored. Buffer length: {0}", this.collectedSamples.Count + 1));
+                QuickPulseEventSource.Log.SampleStoredEvent(this.collectedSamples.Count + 1);
 
                 this.collectedSamples.AddLast(sample);
 

--- a/Src/PerformanceCollector/Shared/Shared.projitems
+++ b/Src/PerformanceCollector/Shared/Shared.projitems
@@ -14,9 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseCollectionTimeSlotManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseDataAccumulatorManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\IQuickPulseServiceClient.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs">
-      <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
-    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulseThreadState.cs"/>
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\QuickPulse\QuickPulsePerfCounters.cs">
       <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
     </Compile>

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseDataSampleTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseDataSampleTests.cs
@@ -304,7 +304,7 @@
             var dataSample = new QuickPulseDataSample(accumulator, this.dummyDictionary);
 
             // ASSERT
-            Assert.AreEqual(0.0, dataSample.PerfIisRequestsPerSecond);
+            Assert.AreEqual(0.0, dataSample.PerfIisQueueSize);
         }
         #endregion
     }

--- a/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryModuleTests.cs
+++ b/Src/PerformanceCollector/Unit.Tests/QuickPulse/QuickPulseTelemetryModuleTests.cs
@@ -357,6 +357,34 @@
             Assert.IsTrue(serviceClient.PingCount > 5);
         }
 
+        [TestMethod]
+        public void QuickPulseTelemetryModuleDisposesCorrectly()
+        {
+            // ARRANGE
+            var interval = TimeSpan.FromMilliseconds(1);
+            var timings = new QuickPulseTimings(interval, interval, interval, interval, interval, interval);
+            var collectionTimeSlotManager = new QuickPulseCollectionTimeSlotManagerMock(timings);
+            var serviceClient = new QuickPulseServiceClientMock { ReturnValueFromPing = true, ReturnValueFromSubmitSample = true };
+            var performanceCollector = new PerformanceCollectorMock();
+            var telemetryProcessor = new QuickPulseTelemetryProcessor(new SimpleTelemetryProcessorSpy());
+
+            var module = new QuickPulseTelemetryModule(
+                collectionTimeSlotManager,
+                null,
+                telemetryProcessor,
+                serviceClient,
+                performanceCollector,
+                timings);
+
+            module.Initialize(new TelemetryConfiguration() { InstrumentationKey = "some ikey" });
+
+            // ACT
+            Thread.Sleep(TimeSpan.FromMilliseconds(100));
+
+            // ASSERT
+            module.Dispose();
+        }
+
         #region Helpers
         private static void SetPrivateProperty(object obj, string propertyName, string propertyValue)
         {


### PR DESCRIPTION
Moving to the best available scheduling model based on load testing.
During the investigation related to issue #38, it was determined that any kind of ThreadPool-dependent scheduling (be that a timer or an async/await loop) is inappropriate for QuickPulse scheduling. As the load increases, QuickPulse threads start competing for ThreadPool's resources with incoming requests, which results in unacceptable delays in data delivery. Since we only need to create 2 threads once and run them for the entirety of the life cycle of the application, ThreadPool is of little to no value to us anyway, so we might as well create the 2 threads ourselves. This eliminates the need for asynchronous code and has an added benefit of decoupling from ThreadPool which handles incoming requests.